### PR TITLE
fixing the bugs in dateinfer (typos and ambiguity)

### DIFF
--- a/dateinfer/infer.py
+++ b/dateinfer/infer.py
@@ -27,6 +27,27 @@ DATE_ELEMENTS = (AMPM(),
 
 F = Filler  # short-hand to clarify rules
 RULES = [
+    #modified to support mm/dd/yyyy (preference to month over DayofMonth: current pip version gives dd/mm/yyyy
+    If(Sequence(MonthNum, F('/'), '\d', F('/'), Year4),
+       SwapSequence([MonthNum, F('/'), '\d', F('/'), Year4], [MonthNum, F('/'), DayOfMonth, F('/'), Year4])),
+    #modified to support mm/dd/yy (preference to month over DayofMonth: current pip version gives dd/mm/hh issue #10
+    If(Sequence(MonthNum, F('/'), '\d', F('/'), Hour24),
+       SwapSequence([MonthNum, F('/'), '\d', F('/'), Hour24], [MonthNum, F('/'), DayOfMonth, F('/'), Year2])),
+   #modified to support mm-dd-yy (preference to month over DayOfMonth: current pip version gives dd-mm-hh
+    If(Sequence(MonthNum, F('-'), '\d', F('-'), Hour24),
+       SwapSequence([MonthNum, F('-'), '\d', F('-'), Hour24], [MonthNum, F('-'), DayOfMonth, F('-'), Year2])),
+   #modified to support mm/dd/yy (preference to month over DayofMonth: current pip version gives dd/mm/mm (12-12-12)
+    If(Sequence(MonthNum, F('/'), '\d', F('/'), MonthNum),
+       SwapSequence([MonthNum, F('/'), '\d', F('/'), MonthNum], [MonthNum, F('/'), DayOfMonth, F('/'), Year2])),
+   #modified to support mm-dd-yy (preference to month over DayOfMonth: current pip version gives dd-mm-mm (12-12-12)
+    If(Sequence(MonthNum, F('-'), '\d', F('-'), MonthNum),
+       SwapSequence([MonthNum, F('-'), '\d', F('-'), MonthNum], [MonthNum, F('-'), DayOfMonth, F('-'), Year2])),
+   #modified to support mm-dd-yyyy (new format)
+    If(Sequence(MonthNum, F('-'), '\d', F('-'), Year4),
+       SwapSequence([MonthNum, F('-'), '\d', F('-'), Year4], [MonthNum, F('-'), DayOfMonth, F('-'), Year4])),
+   #modified to support dd-mm-yyyy (new format)
+    If(Sequence(DayOfMonth, F('-'), '\d', F('-'), Year4),
+       SwapSequence([DayOfMonth, F('-'), '\d', F('-'), Year4], [DayOfMonth, F('-'), MonthNum, F('-'), Year4])),
     If(Sequence(MonthNum, F(':'), '\d', F(':'), '\d'),
        SwapSequence([MonthNum, F(':'), '\d', F(':'), '\d'], [Hour12, F(':'), Minute, F(':'), Second])),
     If(Sequence(Hour24, F(':'), '\d', F(':'), '\d'),
@@ -58,7 +79,8 @@ RULES = [
     If(Sequence(Hour24, '.', MonthNum), SwapSequence([Hour24, '.', MonthNum], [DayOfMonth, KeepOriginal, MonthNum])),
     If(Duplicate(MonthNum), Swap(MonthNum, DayOfMonth)),
     If(Sequence(F('+'), Year4), SwapSequence([F('+'), Year4], [UTCOffset, None])),
-    If(Sequence(F('-'), Year4), SwapSequence([F('+'), Year4], [UTCOffset, None]))
+    #bug modified to support "-0400" type UTCOffset (Gave errors for testcase example.)
+    If(Sequence(F('-'), Year4), SwapSequence([F('-'), Year4], [UTCOffset, None]))
 ]
 
 

--- a/dateinfer/infer.py
+++ b/dateinfer/infer.py
@@ -1,3 +1,8 @@
+"""
+This file contains some modification aimed at fixing bugs and improving the dateinfer library.
+The newlines/modification line are preceded with comments indicating the purpose.
+"""
+
 import collections
 import itertools
 import string


### PR DESCRIPTION
The commit supports new RULES (dd-mm-yyyy, mm-dd-yyyy)
Gives preference for month to precede before DayOfMonth.
bug fixes for "-" UTCOffset.
fixes for issue #10 (1/1/16) -> %d/%m/%H Similarly, for %d-%m-%H
fixes for new issue #10 (1/1/12) -> %d/%m/%m. Similarly, for %d-%d-%m